### PR TITLE
Fix maps in packages

### DIFF
--- a/src/Mapper.elm
+++ b/src/Mapper.elm
@@ -269,11 +269,17 @@ message syntax typeRefs prefixer descriptor =
             prefixer descriptor.name
                 |> Name.type_
 
+        removePackageName : String -> TypeRefs -> String
+        removePackageName typeName (packageName, _, _)=
+            if String.isEmpty packageName then
+                String.dropLeft 1 typeName
+            else String.replace ("." ++ packageName ++ ".") "" typeName
+
         getFromMaps : FieldDescriptorProto -> Maybe { key : FieldType, value : FieldType }
         getFromMaps fieldDescriptor =
             case fieldDescriptor.type_ of
                 FieldDescriptorProto_Type_TYPEMESSAGE ->
-                    Dict.get (String.dropLeft 1 fieldDescriptor.typeName) maps
+                    Dict.get (removePackageName fieldDescriptor.typeName typeRefs) maps
 
                 _ ->
                     Nothing

--- a/tests/elm_protoc_plugin.test.ts
+++ b/tests/elm_protoc_plugin.test.ts
@@ -220,6 +220,27 @@ describe("protoc-gen-elm", () => {
     });
   });
 
+    describe("map_in_package", () => {
+    beforeAll(() => runPlugin("map_in_package.proto"));
+    const expectedElmFileName = "Proto/MapInPackage.elm";
+
+    it("generates a valid elm file for maps", async () => {
+      await compileElm(expectedElmFileName);
+    });
+
+    it("generates working code for maps", async () => {
+      await repl.importModules("Proto.MapInPackage", "Dict");
+      const freshVar = repl.getFreshVariable();
+      await repl.write(
+        `${freshVar} = Proto.MapInPackage.Bar (Dict.singleton "test" (Just <| Proto.MapInPackage.Foo "hi"))`
+      );
+      const output = await repl.write(
+        `(Proto.MapInPackage.encodeBar ${freshVar} |> E.encode |> D.decode Proto.MapInPackage.decodeBar) == Just ${freshVar}`
+      );
+      expect(output).toEqual(expect.stringContaining("True"));
+    });
+  });
+
   describe("nested declarations", () => {
     beforeAll(() => runPlugin("nested.proto"));
     const expectedElmFileName = "Proto/Nested.elm";

--- a/tests/elm_protoc_plugin.test.ts
+++ b/tests/elm_protoc_plugin.test.ts
@@ -220,7 +220,7 @@ describe("protoc-gen-elm", () => {
     });
   });
 
-    describe("map_in_package", () => {
+  describe("map_in_package", () => {
     beforeAll(() => runPlugin("map_in_package.proto"));
     const expectedElmFileName = "Proto/MapInPackage.elm";
 

--- a/tests/proto/map_in_package.proto
+++ b/tests/proto/map_in_package.proto
@@ -1,0 +1,11 @@
+syntax="proto3";
+
+package pack;
+
+message Foo {
+  string abc = 1;
+}
+
+message Bar {
+  map<string, Foo> foos = 1;
+}


### PR DESCRIPTION
Previously of mapping entry type names would fail if the type name had a package prefix