### PR TITLE
Generate encoders/decoders for doubles 

### DIFF
--- a/src/Mapper.elm
+++ b/src/Mapper.elm
@@ -447,7 +447,7 @@ fieldType : DataType -> FieldDescriptorProto -> TypeRefs -> Res FieldType
 fieldType parentDataType descriptor typeRefs =
     case descriptor.type_ of
         FieldDescriptorProto_Type_TYPEDOUBLE ->
-            Ok <| Primitive Prim_Float "double" <| defaultNumber descriptor
+            Ok <| Primitive Prim_Double "double" <| defaultNumber descriptor
 
         FieldDescriptorProto_Type_TYPEFLOAT ->
             Ok <| Primitive Prim_Float "float" <| defaultNumber descriptor

--- a/src/Meta/Decode.elm
+++ b/src/Meta/Decode.elm
@@ -42,6 +42,11 @@ float =
     C.fqFun moduleName "float"
 
 
+double : Expression
+double =
+    C.fqFun moduleName "double"
+
+
 bool : Expression
 bool =
     C.fqFun moduleName "bool"
@@ -94,6 +99,9 @@ forPrimitive prim =
 
         Prim_Int ->
             int32
+
+        Prim_Double ->
+            double
 
 
 moduleName : ModuleName

--- a/src/Meta/Encode.elm
+++ b/src/Meta/Encode.elm
@@ -31,6 +31,10 @@ float : Expression
 float =
     C.fqFun moduleName "float"
 
+double : Expression
+double =
+    C.fqFun moduleName "double"
+
 
 string : Expression
 string =
@@ -69,6 +73,9 @@ forPrimitive prim =
 
         Prim_Bytes ->
             bytes
+
+        Prim_Double ->
+            double
 
 
 message : List Expression -> Expression

--- a/src/Meta/Type.elm
+++ b/src/Meta/Type.elm
@@ -27,3 +27,6 @@ forPrimitive prim =
 
         Prim_Bytes ->
             C.fqTyped [ "Bytes" ] "Bytes" []
+
+        Prim_Double ->
+            C.floatAnn

--- a/src/Model.elm
+++ b/src/Model.elm
@@ -74,6 +74,7 @@ type Primitive
     | Prim_Float
     | Prim_Bool
     | Prim_Bytes
+    | Prim_Double
 
 
 type Field


### PR DESCRIPTION
The generated code was using `Protobuf.Decode.float` to decode doubles instead of `Protobuf.Decode.double`, meaning it could not deserialise messages containing doubles