### PR TITLE
WIP: Fix a code generation edge case where a oneof is named "result"

### DIFF
--- a/tests/elm_protoc_plugin.test.ts
+++ b/tests/elm_protoc_plugin.test.ts
@@ -642,6 +642,14 @@ describe("protoc-gen-elm", () => {
     });
   });
 
+  describe("oneof named 'result'", () => {
+      const expectedElmFileName = "Proto/OneofResult.elm";
+
+      it("generates a valid elm file for a oneof named 'result'", async () => {
+          await compileElm(expectedElmFileName);
+      });
+  })
+
   describe("oneof with enums", () => {
     it("generates working code for a oneof using enums", async () => {
       await repl.importModules(

--- a/tests/proto/oneof_result.proto
+++ b/tests/proto/oneof_result.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+
+package oneof_result;
+
+message Foo {
+  oneof result {
+    string text = 1;
+    int32 code = 2;
+  }
+}


### PR DESCRIPTION
When a oneof is named "result" (or possibly any other Elm prelude name), the code generator tries to add underscores at the end of the name to avoid conflicts. However, sometimes in longer path names in Internals_.elm the underscore is added after a period, not before as it should (e.g. `Foo.Result._Code` vs `Foo.Result_.Code`).

This PR is not a complete fix yet. I have only made a test to demonstrate the issue. The fact that `Mapper.Name.escapeType` appends one underscore and `Mapper.Name.internalize` intersperses double underscores makes it a bit problematic to restore the original values in `Mapper.Name.externalize`. You end up with internal names like `Proto__OneofResult__Foo__Result___Code` (notice the triple underscore at the end), and since `String.split` works eagerly, `externalize` ends up outputting `Proto.OneofResult.Foo.Result._Code` instead of `Proto.OneofResult.Foo.Result_.Code`.

The reason I haven't implemented a complete fix yet is that I was unsure about which approach I should take, and I would like some input before I proceed. I considered changing `externalize` to the following, but that felt a bit too hacky:
```elm
externalize : String -> ( ModuleName, String )
externalize =
    String.reverse
        >> String.split "__"
        >> List.map String.reverse
        >> List.reverse
        >> List.Extra.unconsLast
        >> Maybe.map
            (\( last, rest ) -> ( rest, last ))
        >> Maybe.withDefault ( [], "" )
```
Another alternative would be to change the reserved names suffix from `_` to something like `0`, but I'm not sure how that would interact with everything else. The best approach might just be to use an alternative split implementation so that `split "__" "A___B"` splits into `["A_", "B"]` instead of `["A", "_B"]`.

Thoughts? @anmolitor 